### PR TITLE
Add HTTPS option

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -14,5 +14,6 @@
   <string id="1024">Username</string>
   <string id="1025">Password</string>
   <string id="1026">Set debug level</string>
-  <string id="1027">[I]Log file: ~/.xbmc/userdata/addon_data/service.inadyn/inadyn.log[/I]</string>  
+  <string id="1027">[I]Log file: ~/.xbmc/userdata/addon_data/service.inadyn/inadyn.log[/I]</string>
+  <string id="1028">Use HTTPS (requires provider support)</string>
 </strings>

--- a/resources/language/Turkish/strings.xml
+++ b/resources/language/Turkish/strings.xml
@@ -14,5 +14,6 @@
   <string id="1024">Kullanıcı Adı</string>
   <string id="1025">Parola</string>
   <string id="1026">Hata ayıklama seviyesini ayarla</string>
-  <string id="1027">[I]Log dosyası: ~/.xbmc/userdata/addon_data/service.inadyn/inadyn.log[/I]</string>  
+  <string id="1027">[I]Log dosyası: ~/.xbmc/userdata/addon_data/service.inadyn/inadyn.log[/I]</string>
+  <string id="1028">HTTPS kullanın (sağlayıcı desteği gerektirir)</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -14,4 +14,5 @@
   <setting id="INADYN_UPDATE" type="labelenum" label="1022" values="10|30|60" default="30" enable="eq(-10,true)" visible="eq(-10,true)"/>
   <setting id="INADYN_DBG" type="labelenum" label="1026" values="0|1|2|3|4|5" default="0" enable="eq(-11,true)" visible="eq(-11,true)"/>
   <setting type="text" label="1027" enable="false" visible="eq(-12,true)"/>
+  <setting id="INADYN_SSL" type="bool" label="1028" default="false" enable="eq(-13,true)" visible="eq(-13,true)"/>
 </settings>

--- a/service.py
+++ b/service.py
@@ -57,6 +57,7 @@ class Main:
     self.INADYN_USER = __settings__('INADYN_USER')
     self.INADYN_PWD = __settings__('INADYN_PWD')
     self.INADYN_DBG = __settings__('INADYN_DBG')
+    self.INADYN_SSL = __settings__('INADYN_SSL')
 
     # i386/i686/x86_64/arm binary support
     self.INADYN_EXEC = '%s/bin/inadyn.%s' % (__path__, os.uname()[4])
@@ -89,6 +90,9 @@ class Main:
                      '--cache-dir', xbmc.translatePath(__cachedir__),
                      '--verbose', self.INADYN_DBG,
                      '--background', ]
+
+    if (__settings__('INADYN_SSL').lower() == 'true'):
+      self.inadyn.append('--ssl')
 
   def check(self):
     # check if pid file exist

--- a/service.py
+++ b/service.py
@@ -57,7 +57,6 @@ class Main:
     self.INADYN_USER = __settings__('INADYN_USER')
     self.INADYN_PWD = __settings__('INADYN_PWD')
     self.INADYN_DBG = __settings__('INADYN_DBG')
-    self.INADYN_SSL = __settings__('INADYN_SSL')
 
     # i386/i686/x86_64/arm binary support
     self.INADYN_EXEC = '%s/bin/inadyn.%s' % (__path__, os.uname()[4])


### PR DESCRIPTION
[Basic HTTPS support](https://github.com/troglobit/inadyn/commit/7be3304) was added in inadyn 1.99.8.
This adds a toggle option to the XBMC settings dialog and when enabled appends `--ssl` to the inadyn command.
The option is disabled by default because not all providers support it.
